### PR TITLE
updated submit experience form to use cookies

### DIFF
--- a/frontend/src/Components/ExperienceModal.jsx
+++ b/frontend/src/Components/ExperienceModal.jsx
@@ -1,7 +1,12 @@
 import {useState, useRef} from "react";
 import { MdClose } from "react-icons/md";
 
+import Cookies from "js-cookie"
+
 function ExperienceModal({onClose}){
+
+    const user_id = Cookies.get('user_id')
+
     const [formData, setFormData] = useState({
         title: "",
         description: "",
@@ -30,7 +35,7 @@ function ExperienceModal({onClose}){
         e.preventDefault();
         
         const experienceFormData = {
-            user_id: 19, 
+            user_id: user_id, 
             title: formData.title,
             description: formData.description,
             rating: parseFloat(formData.rating).toFixed(2), 

--- a/frontend/src/Components/TripSearchResults.jsx
+++ b/frontend/src/Components/TripSearchResults.jsx
@@ -5,6 +5,13 @@ import Trip from "./Trip";
 const TripSearchResults = ({input, trips}) => {
 
     const filterArray = () => {
+
+        // If trips is not an array or is empty, return an empty array
+        if (!Array.isArray(trips) || trips.length === 0) {
+            console.warn("No trips available to filter.");
+            return <p>No trips available.</p>; // Message to display when no trips are available
+        }
+
         let filteredArray = trips.filter(trip => trip.title.toLowerCase().includes(input.toLowerCase())
         );
     

--- a/frontend/src/Pages/ViewExperience.jsx
+++ b/frontend/src/Pages/ViewExperience.jsx
@@ -23,7 +23,7 @@ function ViewExperience() {
             })
             .then(data => {
                 console.log(data);
-                setTrips(data)
+                setTrips(Array.isArray(data) ? data : []);
             })
         }, []);
 


### PR DESCRIPTION
This update removes the hard coded user_id and instead uses cookies which store the user_id when logging in.

Also fixed a bug on the MyTrips page and the ViewExperience page that was caused when a user had no trips created. An appropriate message is now displayed.